### PR TITLE
#5feature/5-add-SessionLogin-logout

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="GoogleStyle" />
+  </state>
+</component>

--- a/src/main/java/com/flab/commerce/domain/user/controller/UserApiController.java
+++ b/src/main/java/com/flab/commerce/domain/user/controller/UserApiController.java
@@ -1,10 +1,13 @@
 package com.flab.commerce.domain.user.controller;
 
 import com.flab.commerce.domain.user.domain.User;
+import com.flab.commerce.domain.user.dto.UserRequest.UserLoginRequest;
 import com.flab.commerce.domain.user.dto.UserRequest.UserSignupRequest;
 import com.flab.commerce.domain.user.service.UserService;
 import com.flab.commerce.global.common.CommonResponse;
+import com.flab.commerce.global.common.annotation.CheckUserId;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,6 +25,16 @@ public class UserApiController {
     @PostMapping("/signup")
     public void signup(@RequestBody UserSignupRequest request) {
         userService.signUp(request);
+    }
+
+    @PostMapping("/login")
+    public void login(@RequestBody UserLoginRequest request) {
+        userService.login(request);
+    }
+
+    @DeleteMapping("/logout")
+    public void logout(@CheckUserId Long userId) {
+        userService.logout(userId);
     }
 
     @GetMapping

--- a/src/main/java/com/flab/commerce/domain/user/dto/UserRequest.java
+++ b/src/main/java/com/flab/commerce/domain/user/dto/UserRequest.java
@@ -30,4 +30,17 @@ public class UserRequest {
         @NotBlank(message = "주소지 미입력시 원활한 서비스 이용이 어렵습니다.")
         private String address;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class UserLoginRequest {
+
+        @Email
+        @NotBlank(message = "email은 필수 입력값 입니다.")
+        private String email;
+
+        @NotBlank(message = "비밀 번호를 입력해주세요")
+        @Pattern(regexp = "^[a-z]{8,20}$\n", message = "소문자 8 ~ 20의 문자를 입력해주세요")
+        private String password;
+    }
 }

--- a/src/main/java/com/flab/commerce/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/flab/commerce/domain/user/repository/UserRepository.java
@@ -34,6 +34,12 @@ public class UserRepository {
         return users.containsKey(email);
     }
 
+    public boolean existsByEmailAndPassword(String email, String password) {
+        Long userId = 1L;
+        User user = users.get(userId);
+        return user.getEmail().equals(email) && user.getPassword().equals(password);
+    }
+
 //    void insertUser(User user);
 //
 //    User findByEmail(String email);

--- a/src/main/java/com/flab/commerce/domain/user/service/UserService.java
+++ b/src/main/java/com/flab/commerce/domain/user/service/UserService.java
@@ -1,21 +1,31 @@
 package com.flab.commerce.domain.user.service;
 
+import static com.flab.commerce.global.constant.SessionConst.*;
+
 import com.flab.commerce.domain.user.domain.User;
+import com.flab.commerce.domain.user.dto.UserRequest.UserLoginRequest;
 import com.flab.commerce.domain.user.dto.UserRequest.UserSignupRequest;
 import com.flab.commerce.domain.user.repository.UserRepository;
 import com.flab.commerce.domain.user.service.encryption.EncryptionService;
 import com.flab.commerce.global.common.CommonResponse;
 import com.flab.commerce.global.error.CommonException;
 import com.flab.commerce.global.error.ErrorCode;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository = UserRepository.getInstance();
     private final EncryptionService encoder;
+    /**
+     * 서블릿이 제공하는 기술 서블릿을 통해 session 생성시 JSESSIONID 이라는 이름의 쿠키를 생성 추정 불가한 랜덤값을 넣어준다.
+     */
+    private final HttpSession httpSession;
 
 
     public void signUp(UserSignupRequest request) {
@@ -34,5 +44,25 @@ public class UserService {
             throw new CommonException(ErrorCode.USER_NOT_FOUND);
         }
         return CommonResponse.success(user);
+    }
+
+    public void login(UserLoginRequest request) {
+        String encodedPassword = encoder.encryptPassword(request.getEmail(), request.getPassword());
+        if (!userRepository.existsByEmailAndPassword(request.getEmail(), encodedPassword)) {
+            throw new CommonException(ErrorCode.USER_NOT_FOUND);
+        }
+        User user = userRepository.getUser(1);
+        // 로그인 성공 로직
+        httpSession.setAttribute(LOGIN_USER, user.getUserId());
+        log.info("Logged in user: {}", httpSession.getAttribute(LOGIN_USER));
+    }
+
+    public void logout(Long userId) {
+        try {
+            httpSession.invalidate();
+            log.info("Logged out user: {}", httpSession.getAttribute(LOGIN_USER));
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/flab/commerce/global/common/annotation/CheckUserId.java
+++ b/src/main/java/com/flab/commerce/global/common/annotation/CheckUserId.java
@@ -1,0 +1,15 @@
+package com.flab.commerce.global.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckUserId {
+/**
+ * 세션에 있는 로그인 정보를 조회하는 애노테이션
+ * 사용 위치는 Parameter, 정보가 런타임까지 남아있음
+ */
+}

--- a/src/main/java/com/flab/commerce/global/common/annotation/CheckUserIdArgumentResolver.java
+++ b/src/main/java/com/flab/commerce/global/common/annotation/CheckUserIdArgumentResolver.java
@@ -1,0 +1,39 @@
+package com.flab.commerce.global.common.annotation;
+
+import static com.flab.commerce.global.constant.SessionConst.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class CheckUserIdArgumentResolver implements
+    HandlerMethodArgumentResolver {
+
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+
+        boolean hasAnnotation = parameter.hasParameterAnnotation(CheckUserId.class);
+        boolean typeMatch = Long.class.isAssignableFrom(parameter.getParameterType());
+        return hasAnnotation && typeMatch;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest(
+            HttpServletRequest.class);
+
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return null;
+        }
+
+        return session.getAttribute(LOGIN_USER);
+    }
+}

--- a/src/main/java/com/flab/commerce/global/config/WebConfig.java
+++ b/src/main/java/com/flab/commerce/global/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.flab.commerce.global.config;
+
+import com.flab.commerce.global.common.annotation.CheckUserIdArgumentResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new CheckUserIdArgumentResolver());
+    }
+}

--- a/src/main/java/com/flab/commerce/global/constant/SessionConst.java
+++ b/src/main/java/com/flab/commerce/global/constant/SessionConst.java
@@ -1,0 +1,12 @@
+package com.flab.commerce.global.constant;
+
+/**
+ *세션 조회용 상수 key 역할
+ * 하드 코딩으로도 가능하나 세션을 조회하는 일은 많을 것으로 예상
+ * 혹시라도 key 변경시 하나하나 변경하는것을 막기 위해 사용
+ */
+public class SessionConst {
+
+    public static final String LOGIN_USER = "login_user";
+
+}


### PR DESCRIPTION
## 연관 이슈
ex) #이슈 번호
#5 로그인, 로그아웃

## 작업 내용
- email, password 입력을 통해 로그인 요청
- 비밀번호 불일치시 로그인 실패
- 커스텀 애노테이션을 이용해 세션에 저장된 사용자 정보를 조회
- 사용자는 로그아웃 요청시 invalidate() 를 통해 세션 정보를 무효화후 삭제

## 참고 사항
- 혼자 개발하는 상황으로 상대적으로 구현이 간편함
- 사용자의 규모 미정으로 일단 단일 서버를 상정
> 해당 이유로 session 기반의 로그인 사용